### PR TITLE
[Security] Arbitrary File Read via XXE

### DIFF
--- a/lib/NMWG/Message.pm
+++ b/lib/NMWG/Message.pm
@@ -64,7 +64,7 @@ sub parse_xml {
   my $dom;
   #eval{ 
   if ( $xml_version < 1.7){
-      my $parser = XML::LibXML->new();
+      my $parser = XML::LibXML->new(ext_ent_handler => sub { return ""; });
       $dom = $parser->parse_file($file);
   }else{
       $dom = XML::LibXML->load_xml(location => $file);

--- a/lib/perfSONAR/SOAP/Message.pm
+++ b/lib/perfSONAR/SOAP/Message.pm
@@ -192,9 +192,10 @@ sub from_string {
   my ($source,$uri) = @_;
 
   croak "No XML source to parse" unless $source;
+  my $parser = XML::LibXML->new(ext_ent_handler => sub { return ""; });
   my $dom;
   eval {
-    $dom = XML::LibXML->new->parse_string($source);
+    $dom = $parser->parse_string($source);
   };
   if ($@){
     #TODO Make me a special Exception!
@@ -275,9 +276,10 @@ sub _prepare_nodes {
     } elsif (UNIVERSAL::isa($entry,"XML::LibXML::Node")) {
       push @result, $entry;
     } else {
+      my $parser = XML::LibXML->new(ext_ent_handler => sub { return ""; });
       my $dom;
       eval {
-        $dom = XML::LibXML->new->parse_string($entry);
+        $dom = $parser->parse_string($entry);
       };
       if ($@){
         croak "Error parsing XML source: $@";


### PR DESCRIPTION
LibXML allows the loading of external entities by default allowing unauthenticated arbitrary file read from the system using [XXE](https://www.owasp.org/index.php/XML_External_Entity_%28XXE%29_Processing).

This patch disables external entity processing by creating a `ext_ent_handler` that returns an empty string.
